### PR TITLE
Update coordinate precision to 10 decimals for displaying in JOSM

### DIFF
--- a/src/org/openstreetmap/josm/data/coor/conversion/AbstractCoordinateFormat.java
+++ b/src/org/openstreetmap/josm/data/coor/conversion/AbstractCoordinateFormat.java
@@ -17,7 +17,7 @@ public abstract class AbstractCoordinateFormat implements ICoordinateFormat {
     protected final String displayName;
 
     /** The normal number format for server precision coordinates */
-    protected static final DecimalFormat cDdFormatter = newUnlocalizedDecimalFormat("###0.0######");
+    protected static final DecimalFormat cDdFormatter = newUnlocalizedDecimalFormat("###0.0000000000");
     /** Character denoting South, as string */
     protected static final String SOUTH = trc("compass", "S");
     /** Character denoting North, as string */


### PR DESCRIPTION
We have the requirement to store coordinates with a precision of mm when transformed to UTM32. This requires at least 9 decimals. To be sure we increase this to 10 decimals.

To prevent the length of the coordinate string to jump arround the decimals will be filled with zeros.

Co-Authored-By: fcn-tobi <59211508+fcn-tobi@users.noreply.github.com>